### PR TITLE
fix non-AscII ending args bug

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -13,8 +13,9 @@ func Parse(line string) ([]string, error) {
 	trimmedLine := strings.TrimSpace(line)
 
 	currentArg := []rune{}
+	trimmedLineLen := len(trimmedLine)
 	for i, c := range trimmedLine {
-		isLastChar := i == len(trimmedLine)-1
+		isLastChar := i + len(string(c)) == trimmedLineLen
 
 		if !isInQuote && (c == '"' || c == '\'') {
 			isInQuote = true

--- a/parse_test.go
+++ b/parse_test.go
@@ -113,5 +113,19 @@ func TestParse(t *testing.T) {
 			So(args[6], ShouldEqual, `copy`)
 			So(args[7], ShouldEqual, `c:\path to my dir`)
 		})
+
+		Convey("With non-ACSII ending args", func() {
+			tmpLine = `psexec   \\machine   -u MYDOMAIN\myuser    测试字符串`
+
+			args, err = Parse(tmpLine)
+			So(err, ShouldBeNil)
+			So(len(args), ShouldEqual, 5)
+
+			So(args[0], ShouldEqual, `psexec`)
+			So(args[1], ShouldEqual, `\\machine`)
+			So(args[2], ShouldEqual, `-u`)
+			So(args[3], ShouldEqual, `MYDOMAIN\myuser`)
+			So(args[4], ShouldEqual, `测试字符串`)
+		})
 	})
 }


### PR DESCRIPTION
if the last word is a non-ASCII (multi-byte), "isLastChar" is incorrect.